### PR TITLE
Rocket reservation

### DIFF
--- a/src/components/RocketsPage/rockets.js
+++ b/src/components/RocketsPage/rockets.js
@@ -1,6 +1,9 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { fetchRocket } from '../../redux/rockets/rocketsSlice';
+import {
+  fetchRocket,
+  RocketReservation,
+} from '../../redux/rockets/rocketsSlice';
 import classes from './rockets.module.css';
 
 function RocketPage() {
@@ -19,7 +22,23 @@ function RocketPage() {
           </div>
           <div className={classes.rocketContent}>
             <h2>{rocket.name}</h2>
-            <p>{rocket.description}</p>
+            <p>
+              {rocket.rocketStatus ? (
+                <span className={classes.rocketReserved}>Reserved</span>
+              ) : null}
+              {rocket.description}
+            </p>
+            <button
+              className={
+                rocket.rocketStatus
+                  ? classes.buttonReserved
+                  : classes.buttonNotreserved
+              }
+              type="button"
+              onClick={() => dispatch(RocketReservation(rocket.id))}
+            >
+              {rocket.rocketStatus ? 'Cancel Reservation' : 'Reserve Rocket'}
+            </button>
           </div>
         </div>
       ))}

--- a/src/components/RocketsPage/rockets.module.css
+++ b/src/components/RocketsPage/rockets.module.css
@@ -24,3 +24,70 @@
 .rocketContent p {
   font-size: 17px;
 }
+
+.rocketReserved {
+  margin-right: 0.5rem;
+  color: #fff;
+  background-color: #17a2b8;
+  display: inline-block;
+  padding: 0.25em 0.4em;
+  font-size: 75%;
+  font-weight: 700;
+  line-height: 1;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: 0.25rem;
+}
+
+.buttonNotreserved {
+  background-color: #268fff;
+  opacity: 1;
+  height: 3rem;
+  width: 15rem;
+  color: white;
+}
+
+.buttonReserved:hover,
+.buttonReserved.focus {
+  background-color: #e2e4dd;
+  color: #212529;
+  text-decoration: none;
+  height: 4rem;
+  width: 15rem;
+}
+
+.buttonReserved:focus:not(:focus-visible) {
+  outline: 0;
+  height: 4rem;
+  width: 15rem;
+  background-color: white;
+  color: grey;
+}
+
+.buttonReserved:not(:disabled):not(.disabled) {
+  cursor: pointer;
+  height: 4rem;
+  width: 15rem;
+}
+
+.buttonNotreserved:focus,
+.buttonNotreserved.focus {
+  box-shadow: 0 0 0 0.2rem #268fff;
+  opacity: 1;
+}
+
+.buttonNotreserved:hover,
+.buttonNotreserved.focus {
+  color: #fff;
+  background-color: #0069d9;
+  border-color: #0062cc;
+}
+
+.buttonNotreserved:focus:not(:focus-visible) {
+  outline: 0;
+}
+
+.buttonNotreserved:not(:disabled):not(.disabled) {
+  cursor: pointer;
+}

--- a/src/redux/rockets/rocketsSlice.js
+++ b/src/redux/rockets/rocketsSlice.js
@@ -2,7 +2,7 @@ import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
   rockets: [],
-  toggleStatus: false,
+  rocketStatus: false,
   status: 'idle',
   error: 'no',
 };


### PR DESCRIPTION
### Rocket: reservation

In this PR, I added the initial setup for bookstore.

 ## Activities done
 * [ ] Rockets that have already been reserved seen a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design) .
 * [ ] applay the CSS as look like the design 
 

 # Checklist:
 * [ ] Follows the style guidelines of this project
 * [ ] There is no linters error in my code
 * [ ] follow gitflow 